### PR TITLE
✨ : Add support for non-week number on schedule

### DIFF
--- a/pymadden/api.py
+++ b/pymadden/api.py
@@ -19,8 +19,8 @@ class EARatingsAPI:
             )
 
     def _validate_week_number(self, week_number: int) -> None:
-        if not isinstance(week_number, int) or week_number < 1:
-            raise ValueError("Week number must be a positive integer.")
+        if not isinstance(week_number, int) or (week_number < 0 and week_number not in [0, 19, 20, 21, 22, 23, 79, 99]):
+            raise ValueError("Week number must be a non-negative integer or one of the special iterations.")
 
     def _make_request(self, iteration: str) -> RatingsResponse:
         url = f"{self.BASE_URL}{self.game_version}?filter=iteration:{iteration}"
@@ -36,5 +36,22 @@ class EARatingsAPI:
 
     def get_ratings_by_week(self, week_number: int) -> RatingsResponse:
         self._validate_week_number(week_number)
-        iteration = f"week-{week_number}"
+
+        # Check for special iterations based on the week number
+        special_iterations = {
+            0: "launch-ratings",
+            19: "wild-card-round",
+            20: "divisional-round",
+            21: "conference-championship-round",
+            22: "super-bowl",
+            23: "pro-bowl",
+            79: "rookie-ratings",
+            99: "99-club",
+        }
+
+        if week_number in special_iterations:
+            iteration = special_iterations[week_number]
+        else:
+            iteration = f"week-{week_number}"
+
         return self._make_request(iteration)


### PR DESCRIPTION
This feature enhances the get_ratings_by_week method to handle special iterations based on non-week numbers in the NFL scheduling pattern, providing flexibility in retrieving ratings for different stages of the season.

- Added handling for special iterations based on non-week numbers in the NFL scheduling pattern.
- Updated the `get_ratings_by_week` method to account for the following key/values:
  - rookie-ratings: Rookie Ratings (week 79)
  - 99-club: 99 Club (week 99)
  - launch-ratings: Launch Ratings (week 0)
  - wild-card-round: Wild Card Round Ratings (week 19)
  - divisional-round: Divisional Round Ratings (week 20)
  - conference-championship-round: Conference Championship Ratings (week 21)
  - pro-bowl: Pro Bowl Ratings (week 23)
  - super-bowl: Super Bowl Ratings (week 22)
- Modified the `_validate_week_number` method to allow the special week numbers.