### PR TITLE
🔧 : Fix existing tests with Client

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,9 @@
 # tests/test_api.py
 from unittest.mock import MagicMock, patch
 import pytest
-from pymadden.api import EARatingsAPI
+from pymadden.client import EARatingsClient
 from pymadden.models import RatingsResponse, PlayerRating
 
 def test_api_initialization():
-    api = EARatingsAPI("m23-ratings")
-    assert api.game_version == "m23-ratings"
+    api = EARatingsClient("m23-ratings")
+    assert api.client.game_version == "m23-ratings"


### PR DESCRIPTION
In the updated test, we access the game_version attribute through `api.client.game_version` instead of `api.game_version`. This reflects the change made in the refactored code where the `game_version` is now stored within the `EARatingsClient` object.