### PR TITLE
🔧 :  Update the pre-commit-hook to use Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,13 @@
 repos:
 # ...
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-    -   id: isort
-        args: ["--profile", "black"]
--   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-    -   id: flake8
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    -   id: black
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.3.5
+  hooks:
+    # Run the linter.
+    - id: ruff
+    # Run the formatter.
+    - id: ruff-format
 -   repo: local
     hooks:
       - id: pytest


### PR DESCRIPTION
I pointed the `.pre-commit-config.yaml` to use Ruff instead of Flake8, Black, and isort.  The default functionality is essentially the same.